### PR TITLE
Added fade out animations to tooltips

### DIFF
--- a/TkSolitaire.py
+++ b/TkSolitaire.py
@@ -259,12 +259,23 @@ class ToolTip:
         label = tk.Label(tw, text="  "+self.text+"  ", justify=self.justify, background=self.background,
                          foreground=self.foreground, relief=self.relief, borderwidth=self.borderwidth, font=self.font)
         label.pack(ipadx=1)
-
+    
     def hidetip(self):
-        tw = self.tipwindow
-        self.tipwindow = None
-        if tw:
-            tw.destroy()
+        try:
+            tw = self.tipwindow
+            self.tipwindow = None
+            def fade_away():
+                alpha = tw.attributes("-alpha")
+                if alpha > 0:
+                    alpha -= .1
+                    tw.attributes("-alpha", alpha)
+                    tw.after(10, fade_away)
+                else:
+                    tw.destroy()
+            if tw:
+                fade_away()
+        except:
+            root.after_cancel(task)
 
 
 class SolitareGameWindow(tk.Tk):


### PR DESCRIPTION
I've added fade out animations to tooltips which appear when you hover the mouse on a widget. I couldn't add fade in animation though, as user could move the mouse out of the widget which would glitch the tooltip. I'm working on it.

You can change the fade out speed by changing the number in `tw.after` function call (line 272). Increasing the number will slow the animation down.